### PR TITLE
Allow filter for @PublishedOnLane

### DIFF
--- a/Sources/TimelaneCombine/PublishedOnLane.swift
+++ b/Sources/TimelaneCombine/PublishedOnLane.swift
@@ -11,9 +11,9 @@ import Combine
 /// Property wrapper that offers a publisher for the given property
 /// **and** creates a Timelane lane for it.
 @propertyWrapper public class PublishedOnLane<Value> {
-    
     @Published private var value: Value
     private let laneName: String
+    private let filter: Set<Publishers.LaneType>
     
     /// Gets or sets the value of this property.
     public var wrappedValue: Value {
@@ -23,7 +23,7 @@ import Combine
     
     /// Gets the lane-enabled `Publisher` for this property.
     public var projectedValue: AnyPublisher<Value, Never> {
-        return self.$value.lane(laneName).eraseToAnyPublisher()
+        return self.$value.lane(laneName, filter: filter).eraseToAnyPublisher()
     }
     
     /// Creates a `PublishedOnLane` wrapper.
@@ -32,8 +32,10 @@ import Combine
     ///   - name: The name of this lane; defaults to the
     ///           type of this property if not provided.
     public init(wrappedValue initialValue: Value,
-                _ name: String? = nil) {
+                _ name: String? = nil,
+                _ filter: Set<Publishers.LaneType> = Set(Publishers.LaneType.allCases)) {
         self.value = initialValue
         self.laneName = name ?? "\(initialValue.self)"
+        self.filter = filter
     }
 }

--- a/Sources/TimelaneCombine/PublishedOnLane.swift
+++ b/Sources/TimelaneCombine/PublishedOnLane.swift
@@ -13,7 +13,7 @@ import Combine
 @propertyWrapper public class PublishedOnLane<Value> {
     @Published private var value: Value
     private let laneName: String
-    private let filter: Set<Publishers.LaneType>
+    private let filter: Set<Timelane.LaneType>
     
     /// Gets or sets the value of this property.
     public var wrappedValue: Value {
@@ -33,7 +33,7 @@ import Combine
     ///           type of this property if not provided.
     public init(wrappedValue initialValue: Value,
                 _ name: String? = nil,
-                filter: Set<Publishers.LaneType> = Set(Publishers.LaneType.allCases)) {
+                filter: Set<Timelane.LaneType> = Set(Timelane.LaneType.allCases)) {
         self.value = initialValue
         self.laneName = name ?? "\(initialValue.self)"
         self.filter = filter

--- a/Sources/TimelaneCombine/PublishedOnLane.swift
+++ b/Sources/TimelaneCombine/PublishedOnLane.swift
@@ -33,7 +33,7 @@ import Combine
     ///           type of this property if not provided.
     public init(wrappedValue initialValue: Value,
                 _ name: String? = nil,
-                _ filter: Set<Publishers.LaneType> = Set(Publishers.LaneType.allCases)) {
+                filter: Set<Publishers.LaneType> = Set(Publishers.LaneType.allCases)) {
         self.value = initialValue
         self.laneName = name ?? "\(initialValue.self)"
         self.filter = filter

--- a/Sources/TimelaneCombine/TimelaneCombine.swift
+++ b/Sources/TimelaneCombine/TimelaneCombine.swift
@@ -7,25 +7,24 @@ import Combine
 import TimelaneCore
 
 extension Publishers {
-    
+    public enum LaneType: Int, CaseIterable {
+        case subscription, event
+    }
+
     public class TimelanePublisher<Upstream: Publisher>: Publisher {
-        public enum LaneType: Int, CaseIterable {
-            case subscription, event
-        }
-        
         public typealias Output = Upstream.Output
         public typealias Failure = Upstream.Failure
         
         private let upstream: Upstream
         
         private let subscription: Timelane.Subscription
-        private let filter: Set<LaneType>
+        private let filter: Set<Publishers.LaneType>
         private let source: String
         private let transformValue: (Upstream.Output) -> String
         
         public init(upstream: Upstream,
                     name: String?,
-                    filter: Set<LaneType>,
+                    filter: Set<Publishers.LaneType>,
                     source: String,
                     transformValue: @escaping (Upstream.Output) -> String) {
             self.upstream = upstream
@@ -110,7 +109,7 @@ extension Publisher {
     ///                     it might be more useful to report the count of elements if there are a lot of them.
     ///   - value: The value emitted by the subscription
     public func lane(_ name: String,
-                     filter: Set<Publishers.TimelanePublisher<Self>.LaneType> = Set(Publishers.TimelanePublisher.LaneType.allCases),
+                     filter: Set<Publishers.LaneType> = Set(Publishers.LaneType.allCases),
                      file: StaticString = #file,
                      function: StaticString  = #function, line: UInt = #line,
                      transformValue: @escaping (_ value: Output) -> String = { String(describing: $0) })

--- a/Sources/TimelaneCombine/TimelaneCombine.swift
+++ b/Sources/TimelaneCombine/TimelaneCombine.swift
@@ -7,10 +7,6 @@ import Combine
 import TimelaneCore
 
 extension Publishers {
-    public enum LaneType: Int, CaseIterable {
-        case subscription, event
-    }
-
     public class TimelanePublisher<Upstream: Publisher>: Publisher {
         public typealias Output = Upstream.Output
         public typealias Failure = Upstream.Failure
@@ -18,13 +14,13 @@ extension Publishers {
         private let upstream: Upstream
         
         private let subscription: Timelane.Subscription
-        private let filter: Set<Publishers.LaneType>
+        private let filter: Set<Timelane.LaneType>
         private let source: String
         private let transformValue: (Upstream.Output) -> String
         
         public init(upstream: Upstream,
                     name: String?,
-                    filter: Set<Publishers.LaneType>,
+                    filter: Set<Timelane.LaneType>,
                     source: String,
                     transformValue: @escaping (Upstream.Output) -> String) {
             self.upstream = upstream
@@ -109,7 +105,7 @@ extension Publisher {
     ///                     it might be more useful to report the count of elements if there are a lot of them.
     ///   - value: The value emitted by the subscription
     public func lane(_ name: String,
-                     filter: Set<Publishers.LaneType> = Set(Publishers.LaneType.allCases),
+                     filter: Set<Timelane.LaneType> = Set(Timelane.LaneType.allCases),
                      file: StaticString = #file,
                      function: StaticString  = #function, line: UInt = #line,
                      transformValue: @escaping (_ value: Output) -> String = { String(describing: $0) })


### PR DESCRIPTION
Depends on [TimelaneCore#10](https://github.com/icanzilb/TimelaneCore/pull/10).

Since LaneType is not specific to TimelaneCombine and is duplicated for RxTimelane, LaneType is now part of Core.

Also introduces the ability to filter the @PublishedOnLane property wrapper.